### PR TITLE
CTP-PDFQ v2.3.6

### DIFF
--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -24,13 +24,13 @@ jobs:
         with:
           payload: |
             {
-              "text": "CTP deployment",
+              "text": "CTP Deployment",
               "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "New Release deployed to ${{ github.ref_name }}! ${{ github.event.head_commit.message }} }}"
+                    "text": "New Release deployed to ${{ github.ref_name }}! ${{ github.event.head_commit.message }}"
                   }
                 }
               ]


### PR DESCRIPTION
 * Feature: prefetch images from ZDocs and store in a S3 cache. rewrite image URLs in HTML - AH will fetch from cache.
 * Fix: update 'failed' status for jobs that didn't pass input validation
 * Fix: cached jobs fetch files from the correct S3 path